### PR TITLE
Use STDERR for errors (if available)

### DIFF
--- a/src/Phinx/Console/Command/AbstractCommand.php
+++ b/src/Phinx/Console/Command/AbstractCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use UnexpectedValueException;
 
@@ -439,7 +440,7 @@ abstract class AbstractCommand extends Command
         }
 
         if (!$this->getConfig()->hasEnvironment($environment)) {
-            $output->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
+            self::getErrorOutput($output)->writeln(sprintf('<error>The environment "%s" does not exist</error>', $environment));
 
             return false;
         }
@@ -478,7 +479,7 @@ abstract class AbstractCommand extends Command
             }
             $output->writeln('<info>using database</info> ' . $name, $this->verbosityLevel);
         } else {
-            $output->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
+            self::getErrorOutput($output)->writeln('<error>Could not determine database name! Please specify a database name in your config file.</error>');
 
             return false;
         }
@@ -491,5 +492,16 @@ abstract class AbstractCommand extends Command
         }
 
         return true;
+    }
+
+    /**
+     * Returns the error output to use
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output Output
+     * @return \Symfony\Component\Console\Output\OutputInterface
+     */
+    protected static function getErrorOutput(OutputInterface $output): OutputInterface
+    {
+        return $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
     }
 }

--- a/src/Phinx/Console/Command/ListAliases.php
+++ b/src/Phinx/Console/Command/ListAliases.php
@@ -68,15 +68,17 @@ class ListAliases extends AbstractCommand
                 ),
                 $this->verbosityLevel
             );
-        } else {
-            $output->writeln(
-                sprintf(
-                    '<error>No aliases defined in %s</error>',
-                    Util::relativePath($this->config->getConfigFilePath())
-                )
-            );
+
+            return self::CODE_SUCCESS;
         }
 
-        return self::CODE_SUCCESS;
+        self::getErrorOutput($output)->writeln(
+            sprintf(
+                '<error>No aliases defined in %s</error>',
+                Util::relativePath($this->config->getConfigFilePath())
+            )
+        );
+
+        return self::CODE_ERROR;
     }
 }

--- a/src/Phinx/Console/Command/Migrate.php
+++ b/src/Phinx/Console/Command/Migrate.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace Phinx\Console\Command;
 
 use DateTime;
-use Exception;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -92,12 +91,8 @@ EOT
                 $this->getManager()->migrate($environment, $version, $fake);
             }
             $end = microtime(true);
-        } catch (Exception $e) {
-            $output->writeln('<error>' . $e->__toString() . '</error>');
-
-            return self::CODE_ERROR;
         } catch (Throwable $e) {
-            $output->writeln('<error>' . $e->__toString() . '</error>');
+            self::getErrorOutput($output)->writeln('<error>' . $e->__toString() . '</error>');
 
             return self::CODE_ERROR;
         }

--- a/tests/Phinx/Console/Command/ListAliasesTest.php
+++ b/tests/Phinx/Console/Command/ListAliasesTest.php
@@ -38,7 +38,8 @@ class ListAliasesTest extends TestCase
             ],
             ['decorated' => false]
         );
-        $this->assertEquals(AbstractCommand::CODE_SUCCESS, $exitCode);
+        $expectedExitCode = $hasAliases ? AbstractCommand::CODE_SUCCESS : AbstractCommand::CODE_ERROR;
+        $this->assertSame($expectedExitCode, $exitCode);
 
         $display = $commandTester->getDisplay(false);
 


### PR DESCRIPTION
In the end I chose to copy/adapt `OutputStyle::getErrorOutput` as a new protected method on the abstract command rather than using SymfonyStyle because:
1. creating SymfonyStyle requires both $input and $output, but some existing methods only receive $output
2. SymfonyStyle behaves differently than the plain OutputStyle, which might introduce new issues

I also fixed the exit code for the case where no aliases exist, applying the rule "error output -> exit code 1".